### PR TITLE
[MED-0000] enable manual preprod deployment

### DIFF
--- a/.github/workflows/build_frontend.yml
+++ b/.github/workflows/build_frontend.yml
@@ -1,6 +1,8 @@
 name: Build Frontend
 
-on: push
+on:
+  push:
+  workflow_dispatch:
 
 jobs:
   lint:

--- a/.github/workflows/build_frontend.yml
+++ b/.github/workflows/build_frontend.yml
@@ -24,7 +24,7 @@ jobs:
     name: Build Frontend
     runs-on: ubuntu-latest
     needs: lint
-    if: github.ref != 'refs/heads/main'
+    if: github.ref != 'refs/heads/main' && github.event_name != 'workflow_dispatch'
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -41,7 +41,7 @@ jobs:
     name: Publish Frontend
     runs-on: ubuntu-latest
     needs: lint
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
     steps:
       - name: Check out repository
         uses: actions/checkout@v4


### PR DESCRIPTION
enables manual dispatching of the publish-build job to deploy on the OTC server. A temporary workaround as long as we don't have dev-spaces.