### PR TITLE
[MED-157] Fix unwanted or ugly scrollbar on specific pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,22 @@
       margin: 0; /* <-- Apparently some margin are still there even though it's hidden */
     }
 
+    *::-webkit-scrollbar { /* Try and make scrollnbar uniform across platforms */
+      width: 2px;
+      height: 2px;
+    }
+
+    *::-webkit-scrollbar-track {
+      opacity: 0;
+    }
+
+    *::-webkit-scrollbar-thumb {
+      background-color: rgb(151, 151, 151);    /* color of the scroll thumb */
+      border-radius: 20px;
+      padding-right: 10px;
+    }
+
+
     input[type="number"] {
       -moz-appearance: textfield; /* Firefox */
     }

--- a/src/components/NavBar/LanguageSelector.tsx
+++ b/src/components/NavBar/LanguageSelector.tsx
@@ -36,7 +36,7 @@ const LanguageSelector = () => {
           >
             <LanguageOutlined />
             <ListItemContent>
-              <Typography level="title-sm">
+              <Typography level="title-sm" sx={{ userSelect: "none" }}>
                 {t("components.navbar.languageSelector")}
               </Typography>
             </ListItemContent>
@@ -92,7 +92,9 @@ const LanguageSelector = () => {
                 <ListItemDecorator sx={{ width: "1.5em" }}>
                   {i18n.language === language ? <Check /> : null}
                 </ListItemDecorator>
-                <ListItemContent>{t("languages." + language)}</ListItemContent>
+                <ListItemContent sx={{ userSelect: "none" }}>
+                  {t("languages." + language)}
+                </ListItemContent>
               </ListItemButton>
             </ListItem>
           ))}

--- a/src/components/NavBar/LegalLinksSelector.tsx
+++ b/src/components/NavBar/LegalLinksSelector.tsx
@@ -49,7 +49,7 @@ const LegalLinksSelector = ({
           >
             <InfoOutlined />
             <ListItemContent>
-              <Typography level="title-sm">
+              <Typography level="title-sm" sx={{ userSelect: "none" }}>
                 {t("components.navbar.legalLinks.title")}
               </Typography>
             </ListItemContent>
@@ -100,7 +100,9 @@ const LegalLinksSelector = ({
                   setOpen(false);
                 }}
               >
-                <ListItemContent>{link.label}</ListItemContent>
+                <ListItemContent sx={{ userSelect: "none" }}>
+                  {link.label}
+                </ListItemContent>
               </ListItemButton>
             </ListItem>
           ))}

--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -236,7 +236,7 @@ const NavBar = () => {
               >
                 {element.icon}
                 <ListItemContent>
-                  <Typography level="title-sm">
+                  <Typography level="title-sm" sx={{ userSelect: "none" }}>
                     {t("components.navbar.locationList." + element.path)}
                   </Typography>
                 </ListItemContent>

--- a/src/components/athleteDashboard/AthleteSwimCertificateBox/AthleteSwimCertificateBox.tsx
+++ b/src/components/athleteDashboard/AthleteSwimCertificateBox/AthleteSwimCertificateBox.tsx
@@ -8,6 +8,7 @@ import { Athlete } from "@customTypes/backendTypes";
 import { AuthContext } from "@components/AuthenticationProvider/AuthenticationProvider";
 import { useContext } from "react";
 import { useTranslation } from "react-i18next";
+import { Typography } from "@mui/joy";
 
 const AthleteSwimCertificateBox = () => {
   const { selectedUser } = useContext(AuthContext);
@@ -36,13 +37,13 @@ const AthleteSwimCertificateBox = () => {
         })}
       >
         {athlete?.swimming_certificate ? (
-          <>
+          <Typography sx={{ wordWrap: "break-word" }}>
             {t(
               "components.createSwimCertificateModal.options." +
                 athlete?.swimming_certificate +
                 ".label",
             )}
-          </>
+          </Typography>
         ) : (
           <>
             {t("components.athleteDashboard.swimCertificate.noSwimCertificate")}

--- a/src/components/modals/PerformanceRecordingViewModal/PerformanceRecordingViewModal.tsx
+++ b/src/components/modals/PerformanceRecordingViewModal/PerformanceRecordingViewModal.tsx
@@ -26,6 +26,7 @@ const PerformanceRecordingViewModal = (props: {
       setOpen={props.setOpen}
       modalDialogSX={{
         minWidth: { md: "850px", sx: "90vw" },
+        maxHeight: "80vh",
       }}
     >
       <PerformanceRecordingDatagrid

--- a/src/components/modals/ProfileModal/ProfileModal.tsx
+++ b/src/components/modals/ProfileModal/ProfileModal.tsx
@@ -122,7 +122,7 @@ const ProfileModal = (props: {
           alignItems: "center",
           justifyContent: "center",
           p: "0 50px",
-          overflowY: "scroll",
+          overflowY: "auto",
           overflowX: "hidden",
         }}
       >

--- a/src/utils/disciplineValidationUtil.tsx
+++ b/src/utils/disciplineValidationUtil.tsx
@@ -23,6 +23,7 @@ const isDisciplineInvalid = (
         metric.discipline.id == discipline.id &&
         metric.end_age >= age &&
         metric.start_age <= age &&
+        metric.valid_in == selectedYear &&
         (athlete.gender === "FEMALE"
           ? metric.rating_female != null
           : metric.rating_male != null),


### PR DESCRIPTION
This adds a slim, unified styling to the scroll bars. Additionally, following fixes have been performed:
- Remove static scrollbar for profile page
- Fix overflow of swimming certificate
- Remove user-select from navbar buttons
- Disable disciplines that dont have metrics for the selected year

Tested on Firefox and Edge ( should be equivalent to Edge on Browsers such as Chrome and Safari )

![grafik](https://github.com/user-attachments/assets/302e91bd-10d4-4ec0-b8b8-c6cdbcf32744)
